### PR TITLE
:seedling: batteries: introduce standard completed options type

### DIFF
--- a/server/batteries/options.go
+++ b/server/batteries/options.go
@@ -18,10 +18,12 @@ package batteries
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/pflag"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	genericfeatures "k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
@@ -48,7 +50,11 @@ func (s *Options) AddFlags(fs *pflag.FlagSet) {
 		return
 	}
 
-	fs.StringSliceVar(&s.Enabled, "batteries", []string{}, "The batteries to enable in the generic control-plane server.")
+	bats := sets.NewString()
+	for b := range defaultBatteries {
+		bats = bats.Insert(string(b))
+	}
+	fs.StringSliceVar(&s.Enabled, "batteries", []string{}, "The batteries to enable in the generic control-plane server. Possible values: "+strings.Join(bats.List(), ", "))
 }
 
 // Complete defaults fields that have not set by the consumer of this package.

--- a/server/batteries/options.go
+++ b/server/batteries/options.go
@@ -26,35 +26,61 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
+// Options holds the configuration for the batteries.
+type Options struct {
+	batteries BatteriesList
+	Enabled   []string
+}
+
+type completedOptions struct {
+	batteries BatteriesList
+	Enabled   []string
+}
+
+// CompletedOptions holds the completed configuration for the batteries.
+type CompletedOptions struct {
+	*completedOptions
+}
+
 // AddFlags adds the flags for the admin authentication to the given FlagSet.
-func (s *Batteries) AddFlags(fs *pflag.FlagSet) {
+func (s *Options) AddFlags(fs *pflag.FlagSet) {
 	if s == nil {
 		return
 	}
 
-	fs.StringSliceVar(&s.BatteriesArgs, "batteries", []string{}, "The batteries to enable in the generic control-plane server.")
+	fs.StringSliceVar(&s.Enabled, "batteries", []string{}, "The batteries to enable in the generic control-plane server.")
 }
 
-func (b Batteries) Complete() {
-	// Ensure all some related configuration are configured
-
-	for _, name := range b.BatteriesArgs {
-		if _, ok := b.list[Battery(name)]; ok {
+// Complete defaults fields that have not set by the consumer of this package.
+func (b Options) Complete() CompletedOptions {
+	// Ensure all related configurations are configured
+	for _, name := range b.Enabled {
+		if _, ok := b.batteries[Battery(name)]; ok {
 			b.Enable(Battery(name))
 		}
 	}
 
+	ret := CompletedOptions{
+		&completedOptions{
+			batteries: b.batteries,
+			Enabled:   b.Enabled,
+		},
+	}
+
 	// If lease is disabled, we disable APIServerIdentity
-	if !b.IsEnabled(BatteryLeases) {
+	if !ret.IsEnabled(BatteryLeases) {
 		utilruntime.Must(utilfeature.DefaultMutableFeatureGate.Set(fmt.Sprintf("%s=false", genericfeatures.APIServerIdentity)))
 	}
+
+	return ret
 }
 
-func (b Batteries) Validate() []error {
+// Validate validates the batteries options.
+func (b CompletedOptions) Validate() []error {
 	var errs []error
-	for _, name := range b.BatteriesArgs {
+	for _, name := range b.Enabled {
 		fmt.Println(name)
-		if _, ok := b.list[Battery(name)]; !ok {
+		if _, ok := b.batteries[Battery(name)]; !ok {
 			errs = append(errs, fmt.Errorf("invalid battery %q", name))
 		}
 	}

--- a/server/cmd/options/config.go
+++ b/server/cmd/options/config.go
@@ -48,7 +48,7 @@ type ExtraConfig struct {
 	// authentication
 	GcpAdminToken, UserToken string
 	// Batteries holds the batteries configuration for the generic controlplane server.
-	Batteries batteries.Batteries
+	Batteries batteries.CompletedOptions
 }
 
 type completedConfig struct {
@@ -71,8 +71,6 @@ type CompletedConfig struct {
 
 // Complete fills in any fields not set that are required to have valid data.
 func (c *Config) Complete() (CompletedConfig, error) {
-	c.Batteries.Complete()
-
 	return CompletedConfig{&completedConfig{
 		Options: c.Options,
 
@@ -85,13 +83,13 @@ func (c *Config) Complete() (CompletedConfig, error) {
 	}}, nil
 }
 
-// NewConfig creates all the self-contained pieces making up an
-// generic controlplane server.
+// NewConfig creates all the self-contained pieces making up a generic
+// controlplane server.
 func NewConfig(opts CompletedOptions) (*Config, error) {
 	c := &Config{
 		Options: opts,
 		ExtraConfig: ExtraConfig{
-			Batteries: opts.Extra.Batteries,
+			Batteries: opts.Batteries,
 		},
 	}
 

--- a/server/cmd/server.go
+++ b/server/cmd/server.go
@@ -164,6 +164,7 @@ APIs.`,
 
 	setPartialUsageAndHelpFunc(cmdStart, namedFlagSets, cols, []string{
 		"etcd-servers",
+		"batteries",
 	})
 
 	help.FitTerminal(cmdStart.OutOrStdout())
@@ -295,13 +296,3 @@ func createServerChain(config options.CompletedConfig) (*aggregatorapiserver.API
 
 	return aggregatorServer, nil
 }
-
-type ControlPlaneBattery string
-
-const (
-	ControlPlaneBatteryCore        ControlPlaneBattery = "core"
-	ControlPlaneBatteryFlowControl ControlPlaneBattery = "flowcontrol"
-	ControlPlaneBatteryRBAC        ControlPlaneBattery = "rbac"
-	ControlPlaneBatteryAdmission   ControlPlaneBattery = "admission"
-	ControlPlaneBatteryLease       ControlPlaneBattery = "lease"
-)


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Implement proper `CompletedOptions` for batteries. This helps to enforce correct order, not calling some method early that required completion.

## Related issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
